### PR TITLE
add greater than and less than asserts

### DIFF
--- a/scrutiny/scrutiny.c
+++ b/scrutiny/scrutiny.c
@@ -12,8 +12,8 @@
 #define SCRUTINY_TEXT_BLUE "\033[0;44m"
 #define SCRUTINY_TEXT_RED "\033[0;31m"
 
-#define assert_equal_unsigned_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected != actual) \
+#define assert_unsigned_generic(operator, expected, actual, file, function, line) test_file_expand_and_add(file); \
+    if (!(expected operator actual)) \
     { \
         succeeded_test_contract_and_remove(function); \
         failed_test_expand_and_add(function); \
@@ -22,8 +22,8 @@
     }\
     succeeded_test_expand_and_add(function)
 
-#define assert_equal_signed_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected != actual) \
+#define assert_signed_generic(operator, expected, actual, file, function, line) test_file_expand_and_add(file); \
+    if (!(expected operator actual)) \
     { \
         succeeded_test_contract_and_remove(function); \
         failed_test_expand_and_add(function); \
@@ -32,38 +32,8 @@
     }\
     succeeded_test_expand_and_add(function)
 
-#define assert_equal_floating_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected != actual) \
-    { \
-        succeeded_test_contract_and_remove(function); \
-        failed_test_expand_and_add(function); \
-        failed_test_print_failure_floating(expected, actual, file, function, line, __func__); \
-        return; \
-    }\
-    succeeded_test_expand_and_add(function)
-
-#define assert_not_equal_unsigned_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected == actual) \
-    { \
-        succeeded_test_contract_and_remove(function); \
-        failed_test_expand_and_add(function); \
-        failed_test_print_failure_unsigned_integer(expected, actual, file, function, line, __func__); \
-        return; \
-    }\
-    succeeded_test_expand_and_add(function)
-
-#define assert_not_equal_signed_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected == actual) \
-    { \
-        succeeded_test_contract_and_remove(function); \
-        failed_test_expand_and_add(function); \
-        failed_test_print_failure_signed_integer(expected, actual, file, function, line, __func__); \
-        return; \
-    }\
-    succeeded_test_expand_and_add(function)
-
-#define assert_not_equal_floating_generic(expected, actual, file, function, line, test) test_file_expand_and_add(file); \
-    if (expected == actual) \
+#define assert_floating_generic(operator, expected, actual, file, function, line) test_file_expand_and_add(file); \
+    if (!(expected operator actual)) \
     { \
         succeeded_test_contract_and_remove(function); \
         failed_test_expand_and_add(function); \
@@ -436,242 +406,6 @@ void scrutiny_report_assert_false(bool expression, const char* file, const char*
     succeeded_test_expand_and_add(function);
 }
 
-
-void scrutiny_report_assert_equal_char(char expected, char actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_short(short expected, short actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int(int expected, int actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_long(long expected, long actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_long_long(long long expected, long long actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_float(float expected, float actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_double(double expected, double actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_long_double(long double expected, long double actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line)
-{
-    assert_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line)
-{
-    test_file_expand_and_add(file);
-
-    if (expected != actual)
-    {
-        succeeded_test_contract_and_remove(function);
-        failed_test_expand_and_add(function);
-        failed_test_print_failure_unsigned_integer((uint64_t)expected, (uint64_t)actual, file, function, line, __func__);
-        return;
-    }
-
-    succeeded_test_expand_and_add(function);
-}
-
 void scrutiny_report_assert_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line)
 {
     test_file_expand_and_add(file);
@@ -752,241 +486,6 @@ void scrutiny_report_assert_equal_non_terminated_string(char* expected, char* ac
     succeeded_test_expand_and_add(function);
 }
 
-void scrutiny_report_assert_not_equal_char(char expected, char actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_short(short expected, short actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int(int expected, int actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_long(long expected, long actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_long_long(long long expected, long long actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_float(float expected, float actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_double(double expected, double actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_long_double(long double expected, long double actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_floating_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_unsigned_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line)
-{
-    assert_not_equal_signed_generic(expected, actual, file, function, line, __func__);
-}
-
-void scrutiny_report_assert_not_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line)
-{
-    test_file_expand_and_add(file);
-
-    if (expected == actual)
-    {
-        succeeded_test_contract_and_remove(function);
-        failed_test_expand_and_add(function);
-        failed_test_print_failure_unsigned_integer((uint64_t)expected, (uint64_t)actual, file, function, line, __func__);
-        return;
-    }
-
-    succeeded_test_expand_and_add(function);
-}
-
 void scrutiny_report_assert_not_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line)
 {
     test_file_expand_and_add(file);
@@ -1062,6 +561,190 @@ void scrutiny_report_assert_not_equal_non_terminated_string(char* expected, char
     printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
 }
 
+
+void scrutiny_report_assert_equal_char(char expected, char actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_short(short expected, short actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int(int expected, int actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_long(long expected, long actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_long_long(long long expected, long long actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_float(float expected, float actual, const char* file, const char* function, size_t line) { assert_floating_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_double(double expected, double actual, const char* file, const char* function, size_t line) { assert_floating_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_long_double(long double expected, long double actual, const char* file, const char* function, size_t line) { assert_floating_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(==, expected, actual, file, function, line); }
+void scrutiny_report_assert_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(==, (uintptr_t)expected, (uintptr_t)actual, file, function, line); }
+
+void scrutiny_report_assert_not_equal_char(char expected, char actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_short(short expected, short actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int(int expected, int actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_long(long expected, long actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_long_long(long long expected, long long actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_float(float expected, float actual, const char* file, const char* function, size_t line) { assert_floating_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_double(double expected, double actual, const char* file, const char* function, size_t line) { assert_floating_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_long_double(long double expected, long double actual, const char* file, const char* function, size_t line) { assert_floating_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(!=, expected, actual, file, function, line); }
+void scrutiny_report_assert_not_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(!=, (uintptr_t)expected, (uintptr_t)actual, file, function, line); }
+
+void scrutiny_report_assert_greater_than_char(char expected, char actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_short(short expected, short actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int(int expected, int actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_long(long expected, long actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_long_long(long long expected, long long actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_float(float expected, float actual, const char* file, const char* function, size_t line) { assert_floating_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_double(double expected, double actual, const char* file, const char* function, size_t line) { assert_floating_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_long_double(long double expected, long double actual, const char* file, const char* function, size_t line) { assert_floating_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(>, expected, actual, file, function, line); }
+void scrutiny_report_assert_greater_than_ptr(void* expected, void* actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(>, (uintptr_t)expected, (uintptr_t)actual, file, function, line); }
+
+void scrutiny_report_assert_less_than_char(char expected, char actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_short(short expected, short actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int(int expected, int actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_long(long expected, long actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_long_long(long long expected, long long actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_float(float expected, float actual, const char* file, const char* function, size_t line) { assert_floating_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_double(double expected, double actual, const char* file, const char* function, size_t line) { assert_floating_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_long_double(long double expected, long double actual, const char* file, const char* function, size_t line) { assert_floating_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line) { assert_signed_generic(<, expected, actual, file, function, line); }
+void scrutiny_report_assert_less_than_ptr(void* expected, void* actual, const char* file, const char* function, size_t line) { assert_unsigned_generic(<, (uintptr_t)expected, (uintptr_t)actual, file, function, line); }
 
 void scrutiny_report_benchmark_time(clock_t time, const char* file, const char* function, size_t line)
 {

--- a/scrutiny/scrutiny.h
+++ b/scrutiny/scrutiny.h
@@ -35,6 +35,16 @@
 #define scrutiny_assert_true(expression) scrutiny_report_assert_true(expression, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_false(expression) scrutiny_report_assert_false(expression, __FILE__, __func__, __LINE__)
 
+#define scrutiny_assert_equal_ptr_data(expected, actual, struct_size) scrutiny_report_assert_equal_ptr_data(expected, actual, struct_size, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_equal_array(expected, actual, sizeof_type, array_length) scrutiny_report_assert_equal_array(expected, actual, sizeof_type, array_length, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_equal_string(expected, actual) scrutiny_report_assert_equal_string(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_equal_non_terminated_string(expected, actual, size) scrutiny_report_assert_equal_non_terminated_string(expected, actual, size, __FILE__, __func__, __LINE__)
+
+#define scrutiny_assert_not_equal_ptr_data(expected, actual, struct_size) scrutiny_report_assert_not_equal_ptr_data(expected, actual, struct_size, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_not_equal_array(expected, actual, sizeof_type, array_length) scrutiny_report_assert_not_equal_array(expected, actual, sizeof_type, array_length, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_not_equal_string(expected, actual) scrutiny_report_assert_not_equal_string(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_not_equal_non_terminated_string(expected, actual, size) scrutiny_report_assert_not_equal_non_terminated_string(expected, actual, size, __FILE__, __func__, __LINE__)
+
 #define scrutiny_assert_equal_char(expected, actual) scrutiny_report_assert_equal_char(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_equal_unsigned_char(expected, actual) scrutiny_report_assert_equal_unsigned_char(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_equal_short(expected, actual) scrutiny_report_assert_equal_short(expected, actual, __FILE__, __func__, __LINE__)
@@ -80,10 +90,6 @@
 #define scrutiny_assert_equal_ssize_t(expected, actual) scrutiny_report_assert_equal_ssize_t(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_equal_enum(expected, actual) scrutiny_report_assert_equal_enum(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_equal_ptr(expected, actual) scrutiny_report_assert_equal_ptr(expected, actual, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_equal_ptr_data(expected, actual, struct_size) scrutiny_report_assert_equal_ptr_data(expected, actual, struct_size, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_equal_array(expected, actual, sizeof_type, array_length) scrutiny_report_assert_equal_array(expected, actual, sizeof_type, array_length, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_equal_string(expected, actual) scrutiny_report_assert_equal_string(expected, actual, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_equal_non_terminated_string(expected, actual, size) scrutiny_report_assert_equal_non_terminated_string(expected, actual, size, __FILE__, __func__, __LINE__)
 
 #define scrutiny_assert_not_equal_char(expected, actual) scrutiny_report_assert_not_equal_char(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_not_equal_unsigned_char(expected, actual) scrutiny_report_assert_not_equal_unsigned_char(expected, actual, __FILE__, __func__, __LINE__)
@@ -130,10 +136,98 @@
 #define scrutiny_assert_not_equal_ssize_t(expected, actual) scrutiny_report_assert_not_equal_ssize_t(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_not_equal_enum(expected, actual) scrutiny_report_assert_not_equal_enum(expected, actual, __FILE__, __func__, __LINE__)
 #define scrutiny_assert_not_equal_ptr(expected, actual) scrutiny_report_assert_not_equal_ptr(expected, actual, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_not_equal_ptr_data(expected, actual, struct_size) scrutiny_report_assert_not_equal_ptr_data(expected, actual, struct_size, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_not_equal_array(expected, actual, sizeof_type, array_length) scrutiny_report_assert_not_equal_array(expected, actual, sizeof_type, array_length, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_not_equal_string(expected, actual) scrutiny_report_assert_not_equal_string(expected, actual, __FILE__, __func__, __LINE__)
-#define scrutiny_assert_not_equal_non_terminated_string(expected, actual, size) scrutiny_report_assert_not_equal_non_terminated_string(expected, actual, size, __FILE__, __func__, __LINE__)
+
+#define scrutiny_assert_greater_than_char(expected, actual) scrutiny_report_assert_greater_than_char(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_unsigned_char(expected, actual) scrutiny_report_assert_greater_than_unsigned_char(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_short(expected, actual) scrutiny_report_assert_greater_than_short(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int(expected, actual) scrutiny_report_assert_greater_than_int(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_long(expected, actual) scrutiny_report_assert_greater_than_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_long_long(expected, actual) scrutiny_report_assert_greater_than_long_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_unsigned_short(expected, actual) scrutiny_report_assert_greater_than_unsigned_short(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_unsigned_int(expected, actual) scrutiny_report_assert_greater_than_unsigned_int(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_unsigned_long(expected, actual) scrutiny_report_assert_greater_than_unsigned_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_unsigned_long_long(expected, actual) scrutiny_report_assert_greater_than_unsigned_long_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_float(expected, actual) scrutiny_report_assert_greater_than_float(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_double(expected, actual) scrutiny_report_assert_greater_than_double(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_long_double(expected, actual) scrutiny_report_assert_greater_than_long_double(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int8_t(expected, actual) scrutiny_report_assert_greater_than_int8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int16_t(expected, actual) scrutiny_report_assert_greater_than_int16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int32_t(expected, actual) scrutiny_report_assert_greater_than_int32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int64_t(expected, actual) scrutiny_report_assert_greater_than_int64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_fast8_t(expected, actual) scrutiny_report_assert_greater_than_int_fast8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_fast16_t(expected, actual) scrutiny_report_assert_greater_than_int_fast16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_fast32_t(expected, actual) scrutiny_report_assert_greater_than_int_fast32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_fast64_t(expected, actual) scrutiny_report_assert_greater_than_int_fast64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_least8_t(expected, actual) scrutiny_report_assert_greater_than_int_least8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_least16_t(expected, actual) scrutiny_report_assert_greater_than_int_least16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_least32_t(expected, actual) scrutiny_report_assert_greater_than_int_least32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_int_least64_t(expected, actual) scrutiny_report_assert_greater_than_int_least64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint8_t(expected, actual) scrutiny_report_assert_greater_than_uint8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint16_t(expected, actual) scrutiny_report_assert_greater_than_uint16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint32_t(expected, actual) scrutiny_report_assert_greater_than_uint32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint64_t(expected, actual) scrutiny_report_assert_greater_than_uint64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_fast8_t(expected, actual) scrutiny_report_assert_greater_than_uint_fast8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_fast16_t(expected, actual) scrutiny_report_assert_greater_than_uint_fast16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_fast32_t(expected, actual) scrutiny_report_assert_greater_than_uint_fast32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_fast64_t(expected, actual) scrutiny_report_assert_greater_than_uint_fast64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_least8_t(expected, actual) scrutiny_report_assert_greater_than_uint_least8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_least16_t(expected, actual) scrutiny_report_assert_greater_than_uint_least16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_least32_t(expected, actual) scrutiny_report_assert_greater_than_uint_least32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uint_least64_t(expected, actual) scrutiny_report_assert_greater_than_uint_least64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_intptr_t(expected, actual) scrutiny_report_assert_greater_than_intptr_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uintptr_t(expected, actual) scrutiny_report_assert_greater_than_uintptr_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_intmax_t(expected, actual) scrutiny_report_assert_greater_than_intmax_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_uintmax_t(expected, actual) scrutiny_report_assert_greater_than_uintmax_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_size_t(expected, actual) scrutiny_report_assert_greater_than_size_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_ssize_t(expected, actual) scrutiny_report_assert_greater_than_ssize_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_enum(expected, actual) scrutiny_report_assert_greater_than_enum(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_greater_than_ptr(expected, actual) scrutiny_report_assert_greater_than_ptr(expected, actual, __FILE__, __func__, __LINE__)
+
+#define scrutiny_assert_less_than_char(expected, actual) scrutiny_report_assert_less_than_char(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_unsigned_char(expected, actual) scrutiny_report_assert_less_than_unsigned_char(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_short(expected, actual) scrutiny_report_assert_less_than_short(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int(expected, actual) scrutiny_report_assert_less_than_int(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_long(expected, actual) scrutiny_report_assert_less_than_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_long_long(expected, actual) scrutiny_report_assert_less_than_long_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_unsigned_short(expected, actual) scrutiny_report_assert_less_than_unsigned_short(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_unsigned_int(expected, actual) scrutiny_report_assert_less_than_unsigned_int(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_unsigned_long(expected, actual) scrutiny_report_assert_less_than_unsigned_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_unsigned_long_long(expected, actual) scrutiny_report_assert_less_than_unsigned_long_long(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_float(expected, actual) scrutiny_report_assert_less_than_float(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_double(expected, actual) scrutiny_report_assert_less_than_double(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_long_double(expected, actual) scrutiny_report_assert_less_than_long_double(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int8_t(expected, actual) scrutiny_report_assert_less_than_int8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int16_t(expected, actual) scrutiny_report_assert_less_than_int16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int32_t(expected, actual) scrutiny_report_assert_less_than_int32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int64_t(expected, actual) scrutiny_report_assert_less_than_int64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_fast8_t(expected, actual) scrutiny_report_assert_less_than_int_fast8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_fast16_t(expected, actual) scrutiny_report_assert_less_than_int_fast16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_fast32_t(expected, actual) scrutiny_report_assert_less_than_int_fast32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_fast64_t(expected, actual) scrutiny_report_assert_less_than_int_fast64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_least8_t(expected, actual) scrutiny_report_assert_less_than_int_least8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_least16_t(expected, actual) scrutiny_report_assert_less_than_int_least16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_least32_t(expected, actual) scrutiny_report_assert_less_than_int_least32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_int_least64_t(expected, actual) scrutiny_report_assert_less_than_int_least64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint8_t(expected, actual) scrutiny_report_assert_less_than_uint8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint16_t(expected, actual) scrutiny_report_assert_less_than_uint16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint32_t(expected, actual) scrutiny_report_assert_less_than_uint32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint64_t(expected, actual) scrutiny_report_assert_less_than_uint64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_fast8_t(expected, actual) scrutiny_report_assert_less_than_uint_fast8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_fast16_t(expected, actual) scrutiny_report_assert_less_than_uint_fast16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_fast32_t(expected, actual) scrutiny_report_assert_less_than_uint_fast32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_fast64_t(expected, actual) scrutiny_report_assert_less_than_uint_fast64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_least8_t(expected, actual) scrutiny_report_assert_less_than_uint_least8_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_least16_t(expected, actual) scrutiny_report_assert_less_than_uint_least16_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_least32_t(expected, actual) scrutiny_report_assert_less_than_uint_least32_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uint_least64_t(expected, actual) scrutiny_report_assert_less_than_uint_least64_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_intptr_t(expected, actual) scrutiny_report_assert_less_than_intptr_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uintptr_t(expected, actual) scrutiny_report_assert_less_than_uintptr_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_intmax_t(expected, actual) scrutiny_report_assert_less_than_intmax_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_uintmax_t(expected, actual) scrutiny_report_assert_less_than_uintmax_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_size_t(expected, actual) scrutiny_report_assert_less_than_size_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_ssize_t(expected, actual) scrutiny_report_assert_less_than_ssize_t(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_enum(expected, actual) scrutiny_report_assert_less_than_enum(expected, actual, __FILE__, __func__, __LINE__)
+#define scrutiny_assert_less_than_ptr(expected, actual) scrutiny_report_assert_less_than_ptr(expected, actual, __FILE__, __func__, __LINE__)
 
 /* 
  * Use these macros in such a way that your benchmark may setup before starting
@@ -247,6 +341,16 @@ void scrutiny_report_assert_fail(const char* file, const char* function, size_t 
 void scrutiny_report_assert_true(bool expression, const char* file, const char* function, size_t line); /* Checks if the boolean expression is true. */
 void scrutiny_report_assert_false(bool expression, const char* file, const char* function, size_t line); /* Checks if the boolean expression is false. */
 
+void scrutiny_report_assert_not_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line); /* Checks if the data at the pointer expected is the same as actual. */
+void scrutiny_report_assert_not_equal_array(void* expected, void* actual, size_t sizeof_type, size_t array_length, const char* file, const char* function, size_t line); /* Checks if the expected array and actual array are equal. */
+void scrutiny_report_assert_not_equal_string(char* expected, char* actual, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
+void scrutiny_report_assert_not_equal_non_terminated_string(char* expected, char* actual, size_t size, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
+
+void scrutiny_report_assert_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line); /* Checks if the data at the pointer expected is the same as actual. */
+void scrutiny_report_assert_equal_array(void* expected, void* actual, size_t sizeof_type, size_t array_length, const char* file, const char* function, size_t line); /* Checks if the expected array and actual array are equal. */
+void scrutiny_report_assert_equal_string(char* expected, char* actual, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
+void scrutiny_report_assert_equal_non_terminated_string(char* expected, char* actual, size_t size, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
+
 void scrutiny_report_assert_equal_char(char expected, char actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
 void scrutiny_report_assert_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
 void scrutiny_report_assert_equal_short(short expected, short actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
@@ -292,10 +396,6 @@ void scrutiny_report_assert_equal_size_t(size_t expected, size_t actual, const c
 void scrutiny_report_assert_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line); /* Checks if expected is equal to actual. */
 void scrutiny_report_assert_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line); /* Checks if two enum values (ints) are the same. */
 void scrutiny_report_assert_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line); /* Checks if the expected pointer and actual pointer are the same. */
-void scrutiny_report_assert_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line); /* Checks if the data at the pointer expected is the same as actual. */
-void scrutiny_report_assert_equal_array(void* expected, void* actual, size_t sizeof_type, size_t array_length, const char* file, const char* function, size_t line); /* Checks if the expected array and actual array are equal. */
-void scrutiny_report_assert_equal_string(char* expected, char* actual, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
-void scrutiny_report_assert_equal_non_terminated_string(char* expected, char* actual, size_t size, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
 
 void scrutiny_report_assert_not_equal_char(char expected, char actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
 void scrutiny_report_assert_not_equal_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
@@ -342,10 +442,98 @@ void scrutiny_report_assert_not_equal_size_t(size_t expected, size_t actual, con
 void scrutiny_report_assert_not_equal_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line); /* Checks if expected is equal to actual. */
 void scrutiny_report_assert_not_equal_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line); /* Checks if two enum values (ints) are the same. */
 void scrutiny_report_assert_not_equal_ptr(void* expected, void* actual, const char* file, const char* function, size_t line); /* Checks if the expected pointer and actual pointer are the same. */
-void scrutiny_report_assert_not_equal_ptr_data(void* expected, void* actual, size_t struct_size, const char* file, const char* function, size_t line); /* Checks if the data at the pointer expected is the same as actual. */
-void scrutiny_report_assert_not_equal_array(void* expected, void* actual, size_t sizeof_type, size_t array_length, const char* file, const char* function, size_t line); /* Checks if the expected array and actual array are equal. */
-void scrutiny_report_assert_not_equal_string(char* expected, char* actual, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
-void scrutiny_report_assert_not_equal_non_terminated_string(char* expected, char* actual, size_t size, const char* file, const char* function, size_t line); /* Checks if the two strings are equal. */
+
+void scrutiny_report_assert_greater_than_char(char expected, char actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_short(short expected, short actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int(int expected, int actual, const char* file, const char* function, size_t line); /* Checks if expected is equivilant to actual. */
+void scrutiny_report_assert_greater_than_long(long expected, long actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_long_long(long long expected, long long actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_float(float expected, float actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_double(double expected, double actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_long_double(long double expected, long double actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line); /* Checks if expected is greater than actual. */
+void scrutiny_report_assert_greater_than_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line); /* Checks if the expected enum value is greater than actual. */
+void scrutiny_report_assert_greater_than_ptr(void* expected, void* actual, const char* file, const char* function, size_t line); /* Checks if the expected pointer is greater than the actual pointer. */
+
+void scrutiny_report_assert_less_than_char(char expected, char actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_unsigned_char(unsigned char expected, unsigned char actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_short(short expected, short actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int(int expected, int actual, const char* file, const char* function, size_t line); /* Checks if expected is elessnt to actual. */
+void scrutiny_report_assert_less_than_long(long expected, long actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_long_long(long long expected, long long actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_unsigned_short(unsigned short expected, unsigned short actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_unsigned_int(unsigned int expected, unsigned int actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_unsigned_long(unsigned long expected, unsigned long actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_unsigned_long_long(unsigned long long expected, unsigned long long actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_float(float expected, float actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_double(double expected, double actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_long_double(long double expected, long double actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int8_t(int8_t expected, int8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int16_t(int16_t expected, int16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int32_t(int32_t expected, int32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int64_t(int64_t expected, int64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_fast8_t(int_fast8_t expected, int_fast8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_fast16_t(int_fast16_t expected, int_fast16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_fast32_t(int_fast32_t expected, int_fast32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_fast64_t(int_fast64_t expected, int_fast64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_least8_t(int_least8_t expected, int_least8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_least16_t(int_least16_t expected, int_least16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_least32_t(int_least32_t expected, int_least32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_int_least64_t(int_least64_t expected, int_least64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint8_t(uint8_t expected, uint8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint16_t(uint16_t expected, uint16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint32_t(uint32_t expected, uint32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint64_t(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_fast8_t(uint_fast8_t expected, uint_fast8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_fast16_t(uint_fast16_t expected, uint_fast16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_fast32_t(uint_fast32_t expected, uint_fast32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_fast64_t(uint_fast64_t expected, uint_fast64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_least8_t(uint_least8_t expected, uint_least8_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_least16_t(uint_least16_t expected, uint_least16_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_least32_t(uint_least32_t expected, uint_least32_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uint_least64_t(uint_least64_t expected, uint_least64_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_intptr_t(intptr_t expected, intptr_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uintptr_t(uintptr_t expected, uintptr_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_intmax_t(intmax_t expected, intmax_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_uintmax_t(uintmax_t expected, uintmax_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_size_t(size_t expected, size_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_ssize_t(ssize_t expected, ssize_t actual, const char* file, const char* function, size_t line); /* Checks if expected is less than actual. */
+void scrutiny_report_assert_less_than_enum(enum_value_t expected, enum_value_t actual, const char* file, const char* function, size_t line); /* Checks if the expected enum value is less than actual. */
+void scrutiny_report_assert_less_than_ptr(void* expected, void* actual, const char* file, const char* function, size_t line); /* Checks if the expected pointer is less than the actual pointer. */
 
 void scrutiny_report_benchmark_time(clock_t time, const char* file, const char* function, size_t line); /* Records the given benchmark time. */
 


### PR DESCRIPTION
Adds both a greater than and less than assertion for all numeric types and refactors the generic assertion macros to now take the comparison operator as an argument.