### PR TITLE
Support non test assertions

### DIFF
--- a/examples/runtime_assertion.c
+++ b/examples/runtime_assertion.c
@@ -1,0 +1,22 @@
+#include "../scrutiny/scrutiny.h"
+
+/*
+ * Shows how you can use scrutiny's assertions as an alternative to the
+ * standard library's during application runtime or debugging.
+ */
+
+int main()
+{
+	int a = 8;
+	int b = 4;
+
+	scrutiny_assert_equal_int(a, b * 2);
+	printf("Passed One!");
+
+	int arr1[] = { 2, 4, 6, 8 };
+	int arr2[] = { 2, 4, 5, 7 };
+
+	scrutiny_assert_not_equal_array(arr1, arr2, sizeof(int), sizeof arr1);
+	scrutiny_assert_equal_int(arr1[2], arr2[2]);
+}
+

--- a/examples/runtime_assertion.c
+++ b/examples/runtime_assertion.c
@@ -11,7 +11,12 @@ int main()
 	int b = 4;
 
 	scrutiny_assert_equal_int(a, b * 2);
-	printf("Passed One!");
+	printf("Passed One!\n");
+
+	/*
+	 * If you want to make runtime assertions like this after running unit tests
+	 * you will need to make a call to scrutiny_clear_results().
+	 */
 
 	int arr1[] = { 2, 4, 6, 8 };
 	int arr2[] = { 2, 4, 5, 7 };

--- a/scrutiny/scrutiny.c
+++ b/scrutiny/scrutiny.c
@@ -156,6 +156,9 @@ static void failed_test_print_failure(const char* expected, const char* actual, 
 
     printf("\tExpected:  %s\n", expected);
     printf("\tActual:    %s\n", actual);
+
+    if (test_results == NULL)
+        exit(EXIT_FAILURE);
 }
 
 static void failed_test_print_failure_unsigned_integer(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line, const char* assert)
@@ -204,7 +207,7 @@ void scrutiny_run_tests(scrutiny_unit_test_t* scrutiny_unit_tests)
 {
     test_results = malloc(sizeof(scrutiny_test_results_t));
     memset(test_results, 0, sizeof(scrutiny_test_results_t));
-    
+
     for (size_t test = 0; scrutiny_unit_tests[test] != NULL; test++)
         scrutiny_unit_tests[test]();
 }
@@ -382,15 +385,21 @@ int scrutiny_output_benchmark_results_parsable(file_t* file)
 
 void scrutiny_clear_results(void)
 {
-    free(test_results->passed_test_names);
-    free(test_results->failed_test_names);
-    free(test_results->file_names);
-    free(test_results);
+    if (test_results != NULL)
+    {
+        free(test_results->passed_test_names);
+        free(test_results->failed_test_names);
+        free(test_results->file_names);
+        free(test_results);
+    }
 
-    free(benchmark_results->benchmark_names);
-    free(benchmark_results->benchmark_times);
-    free(benchmark_results->file_names);
-    free(benchmark_results);
+    if (benchmark_results != NULL)
+    {
+        free(benchmark_results->benchmark_names);
+        free(benchmark_results->benchmark_times);
+        free(benchmark_results->file_names);
+        free(benchmark_results);
+    }
 
     test_results = NULL;
     benchmark_results = NULL;

--- a/scrutiny/scrutiny.c
+++ b/scrutiny/scrutiny.c
@@ -4,6 +4,7 @@
  */
 
 #include "scrutiny.h"
+#include <string.h>
 
 #define SCRUTINY_TEXT_NORMAL "\033[0m"
 #define SCRUTINY_TEXT_BOLD "\033[1m"
@@ -50,19 +51,8 @@ struct in_progress_average_s
     clock_t running_total;
 };
 
-static size_t failed_cases = 0;
-static size_t passed_cases = 0;
-static size_t failed_tests_length = 0;
-static size_t passed_tests_length = 0;
-static const char** failed_tests = NULL;
-static const char** passed_tests = NULL;
-static size_t test_files_length = 0;
-static const char** test_files = NULL;
-
-static size_t benchmarks = 0;
-static clock_t* benchmark_times = NULL;
-static const char** benchmark_names = NULL;
-static const char** benchmark_files = NULL;
+static scrutiny_test_results_t* test_results = NULL;
+static scrutiny_benchmark_results_t* benchmark_results = NULL;
 
 static bool compare_null_terminated_strings(const char* str0, const char* str1)
 {
@@ -79,32 +69,38 @@ static bool compare_null_terminated_strings(const char* str0, const char* str1)
 
 static void succeeded_test_expand_and_add(const char* succeeded_test)
 {
-    passed_cases++;
+    if (test_results == NULL)
+        return;
+
+    test_results->passed_cases++;
     
-    for (size_t i = 0; i < passed_tests_length; i++)
-        if (compare_null_terminated_strings(passed_tests[i], succeeded_test))
+    for (size_t i = 0; i < test_results->passed_tests; i++)
+        if (compare_null_terminated_strings(test_results->passed_test_names[i], succeeded_test))
             return;
 
     /* If the test function has failed previously dont add it to the succeeded list. */
-    for (size_t i = 0; i < failed_tests_length; i++)
-        if (compare_null_terminated_strings(failed_tests[i], succeeded_test))
+    for (size_t i = 0; i < test_results->failed_tests; i++)
+        if (compare_null_terminated_strings(test_results->failed_test_names[i], succeeded_test))
             return;
     
-    passed_tests_length++;
-    passed_tests = reallocarray(passed_tests, passed_tests_length, sizeof(char*));
-    passed_tests[passed_tests_length - 1] = succeeded_test;
+    test_results->passed_tests++;
+    test_results->passed_test_names = reallocarray(test_results->passed_test_names, test_results->passed_tests, sizeof(char*));
+    test_results->passed_test_names[test_results->passed_tests - 1] = succeeded_test;
 }
 
 static void succeeded_test_contract_and_remove(const char* test)
 {
-    for (size_t i = 0; i < passed_tests_length; i++)
-    {
-        if (compare_null_terminated_strings(passed_tests[i], test))
-        {
-            if (i != passed_tests_length - 1)
-                passed_tests[i] = passed_tests[passed_tests_length - 1];
+    if (test_results == NULL)
+        return;
 
-            passed_tests_length--;
+    for (size_t i = 0; i < test_results->passed_tests; i++)
+    {
+        if (compare_null_terminated_strings(test_results->passed_test_names[i], test))
+        {
+            if (i != test_results->passed_tests - 1)
+                test_results->passed_test_names[i] = test_results->passed_test_names[test_results->passed_tests - 1];
+
+            test_results->passed_tests--;
             return;
         }
     }
@@ -112,111 +108,133 @@ static void succeeded_test_contract_and_remove(const char* test)
 
 static void failed_test_expand_and_add(const char* failed_test)
 {
-    failed_cases++;
+    if (test_results == NULL)
+        return;
     
-    for (size_t i = 0; i < failed_tests_length; i++)
-        if (compare_null_terminated_strings(failed_tests[i], failed_test))
+    test_results->failed_cases++;
+    
+    for (size_t i = 0; i < test_results->failed_tests; i++)
+        if (compare_null_terminated_strings(test_results->failed_test_names[i], failed_test))
             return;
 
-    failed_tests_length++;
-    failed_tests = reallocarray(failed_tests, failed_tests_length, sizeof(char*));
-    failed_tests[failed_tests_length - 1] = failed_test;
+    test_results->failed_tests++;
+    test_results->failed_test_names = reallocarray(test_results->failed_test_names, test_results->failed_tests, sizeof(char*));
+    test_results->failed_test_names[test_results->failed_tests - 1] = failed_test;
 }
 
 static void test_file_expand_and_add(const char* test_file)
 {
-    for (size_t i = 0; i < test_files_length; i++)
-        if (compare_null_terminated_strings(test_files[i], test_file))
+    if (test_results == NULL)
+        return;
+
+    for (size_t i = 0; i < test_results->files; i++)
+        if (compare_null_terminated_strings(test_results->file_names[i], test_file))
             return;
 
-    test_files_length++;
-    test_files = reallocarray(test_files, test_files_length, sizeof(char*));
-    test_files[test_files_length - 1] = test_file;
+    test_results->files++;
+    test_results->file_names = reallocarray(test_results->file_names, test_results->files, sizeof(char*));
+    test_results->file_names[test_results->files - 1] = test_file;
 }
 
 static void benchmark_run_expand_and_add(const char* name, const char* file, clock_t time)
 {
-    benchmarks++;
-    benchmark_names = reallocarray(benchmark_names, benchmarks, sizeof(char*));
-    benchmark_times = reallocarray(benchmark_times, benchmarks, sizeof(char*));
-    benchmark_files = reallocarray(benchmark_files, benchmarks, sizeof(char*));
-    benchmark_names[benchmarks - 1] = name;
-    benchmark_times[benchmarks - 1] = time;
-    benchmark_files[benchmarks - 1] = file;
+    benchmark_results->benchmarks++;
+    benchmark_results->benchmark_names = reallocarray(benchmark_results->benchmark_names, benchmark_results->benchmarks, sizeof(char*));
+    benchmark_results->benchmark_times = reallocarray(benchmark_results->benchmark_times, benchmark_results->benchmarks, sizeof(char*));
+    benchmark_results->file_names = reallocarray(benchmark_results->file_names, benchmark_results->benchmarks, sizeof(char*));
+    benchmark_results->benchmark_names[benchmark_results->benchmarks - 1] = name;
+    benchmark_results->benchmark_times[benchmark_results->benchmarks - 1] = time;
+    benchmark_results->file_names[benchmark_results->benchmarks - 1] = file;
 }
 
 static void failed_test_print_failure(const char* expected, const char* actual, const char* file, const char* function, size_t line, const char* assert)
 {
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, assert, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+
     printf("\tExpected:  %s\n", expected);
     printf("\tActual:    %s\n", actual);
 }
 
 static void failed_test_print_failure_unsigned_integer(uint64_t expected, uint64_t actual, const char* file, const char* function, size_t line, const char* assert)
 {
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, assert, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+
     printf("\tExpected:  %zu\n", expected);
     printf("\tActual:    %zu\n", actual);
+
+    if (test_results == NULL)
+        exit(EXIT_FAILURE);
 }
 
 static void failed_test_print_failure_signed_integer(int64_t expected, int64_t actual, const char* file, const char* function, size_t line, const char* assert)
 {
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, assert, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+
     printf("\tExpected:  %zi\n", expected);
     printf("\tActual:    %zi\n", actual);
+
+    if (test_results == NULL)
+        exit(EXIT_FAILURE);
 }
 
 static void failed_test_print_failure_floating(long double expected, long double actual, const char* file, const char* function, size_t line, const char* assert)
 {
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, assert, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, assert, line);
+
     printf("\tExpected:  %Lf\n", expected);
     printf("\tActual:    %Lf\n", actual);
+
+    if (test_results == NULL)
+        exit(EXIT_FAILURE);
 }
 
 void scrutiny_run_tests(scrutiny_unit_test_t* scrutiny_unit_tests)
 {
+    test_results = malloc(sizeof(scrutiny_test_results_t));
+    memset(test_results, 0, sizeof(scrutiny_test_results_t));
+    
     for (size_t test = 0; scrutiny_unit_tests[test] != NULL; test++)
         scrutiny_unit_tests[test]();
 }
 
 void scrutiny_run_benchmarks(scrutiny_benchmark_t* scrutiny_benchmarks)
 {
+    benchmark_results = malloc(sizeof(scrutiny_benchmark_results_t));
+    memset(benchmark_results, 0, sizeof(scrutiny_benchmark_results_t));
+    
     for (size_t benchmark = 0; scrutiny_benchmarks[benchmark] != NULL; benchmark++)
         scrutiny_benchmarks[benchmark]();
 }
 
 void scrutiny_run_benchmarks_n_times(scrutiny_benchmark_t* scrutiny_benchmarks, size_t n)
 {
+    benchmark_results = malloc(sizeof(scrutiny_benchmark_results_t));
+    memset(benchmark_results, 0, sizeof(scrutiny_benchmark_results_t));
+    
     for (size_t benchmark = 0; scrutiny_benchmarks[benchmark] != NULL; benchmark++)
         for (size_t i = 0; i < n; i++)
             scrutiny_benchmarks[benchmark]();
 }
 
-scrutiny_test_results_t scrutiny_get_test_results(void)
+scrutiny_test_results_t* scrutiny_get_test_results(void)
 {
-    scrutiny_test_results_t test_results = 
-    {
-        .failed_cases = failed_cases,
-        .passed_cases = passed_cases,
-        .failed_tests = failed_tests_length,
-        .passed_tests = passed_tests_length,
-        .failed_test_names = failed_tests,
-        .passed_test_names = passed_tests
-    };
-
     return test_results;
 }
 
-scrutiny_benchmark_results_t scrutiny_get_benchmark_results(void)
+scrutiny_benchmark_results_t* scrutiny_get_benchmark_results(void)
 {
-    scrutiny_benchmark_results_t benchmark_results = 
-    {
-        .benchmarks = benchmarks,
-        .benchmark_names = benchmark_names,
-        .benchmark_times = benchmark_times,
-        .file_names = benchmark_files
-    };
-
     return benchmark_results;
 }
 
@@ -225,29 +243,29 @@ int scrutiny_output_test_results(file_t* out_file)
     if (out_file == NULL)
         return 1;
 
-    long double percent_passed = ((long double)passed_tests_length / (long double)(passed_tests_length + failed_tests_length)) * 100.0;
-    long double percent_failed = ((long double)failed_tests_length / (long double)(passed_tests_length + failed_tests_length)) * 100.0;
-    long double percent_cases_passed = ((long double)passed_cases / (long double)(passed_cases + failed_cases)) * 100.0;
-    long double percent_cases_failed = ((long double)failed_cases / (long double)(passed_cases + failed_cases)) * 100.0;
+    long double percent_passed = ((long double)test_results->passed_tests / (long double)(test_results->passed_tests + test_results->failed_tests)) * 100.0;
+    long double percent_failed = ((long double)test_results->failed_tests / (long double)(test_results->passed_tests + test_results->failed_tests)) * 100.0;
+    long double percent_cases_passed = ((long double)test_results->passed_cases / (long double)(test_results->passed_cases + test_results->failed_cases)) * 100.0;
+    long double percent_cases_failed = ((long double)test_results->failed_cases / (long double)(test_results->passed_cases + test_results->failed_cases)) * 100.0;
 
-    fprintf(out_file, "Scrutiny ran %zu test cases, from %zu tests, in %zu files.\n\n", failed_cases + passed_cases, failed_tests_length + passed_tests_length, test_files_length);
+    fprintf(out_file, "\nScrutiny ran %zu test cases, from %zu tests, in %zu files.\n\n", test_results->failed_cases + test_results->passed_cases, test_results->passed_tests + test_results->failed_tests, test_results->files);
 
-    if (failed_tests_length > 0)
+    if (test_results->failed_tests > 0)
         fprintf(out_file, "Failed tests:\n");
 
-    for (size_t i = 0; i < failed_tests_length; i++)
-        fprintf(out_file, SCRUTINY_TEXT_ITALIC "\t%s\n" SCRUTINY_TEXT_NORMAL, failed_tests[i]);
+    for (size_t i = 0; i < test_results->failed_tests; i++)
+        fprintf(out_file, SCRUTINY_TEXT_ITALIC "\t%s\n" SCRUTINY_TEXT_NORMAL, test_results->failed_test_names[i]);
 
-    if (passed_cases > 0)
+    if (test_results->passed_cases > 0)
     {
-        fprintf(out_file, "\n(" SCRUTINY_TEXT_GREEN "" SCRUTINY_TEXT_NORMAL ") %zu of %zu tests passed (%2.1Lf%%).", passed_tests_length, passed_tests_length + failed_tests_length, percent_passed);
-        fprintf(out_file, "\t(" SCRUTINY_TEXT_GREEN "" SCRUTINY_TEXT_NORMAL ") %zu of %zu test cases passed (%2.1Lf%%).\n", passed_cases, passed_cases + failed_cases, percent_cases_passed);
+        fprintf(out_file, "\n(" SCRUTINY_TEXT_GREEN "" SCRUTINY_TEXT_NORMAL ") %zu of %zu tests passed (%2.1Lf%%).", test_results->passed_tests, test_results->passed_tests + test_results->failed_tests, percent_passed);
+        fprintf(out_file, "\t(" SCRUTINY_TEXT_GREEN "" SCRUTINY_TEXT_NORMAL ") %zu of %zu test cases passed (%2.1Lf%%).\n", test_results->passed_cases, test_results->passed_cases + test_results->failed_cases, percent_cases_passed);
     }
 
-    if (failed_cases > 0)
+    if (test_results->failed_cases > 0)
     {
-        fprintf(out_file, "(" SCRUTINY_TEXT_RED "x" SCRUTINY_TEXT_NORMAL ") %zu of %zu tests failed (%2.1Lf%%).", failed_tests_length, passed_tests_length + failed_tests_length, percent_failed);
-        fprintf(out_file, "\t(" SCRUTINY_TEXT_RED "x" SCRUTINY_TEXT_NORMAL ") %zu of %zu test cases failed (%2.1Lf%%).\n", failed_cases, failed_cases + passed_cases, percent_cases_failed);
+        fprintf(out_file, "(" SCRUTINY_TEXT_RED "x" SCRUTINY_TEXT_NORMAL ") %zu of %zu tests failed (%2.1Lf%%).", test_results->failed_tests, test_results->passed_tests + test_results->passed_tests, percent_failed);
+        fprintf(out_file, "\t(" SCRUTINY_TEXT_RED "x" SCRUTINY_TEXT_NORMAL ") %zu of %zu test cases failed (%2.1Lf%%).\n", test_results->failed_cases, test_results->passed_cases + test_results->failed_cases, percent_cases_failed);
     }
 
     fflush(out_file);
@@ -267,14 +285,14 @@ int scrutiny_output_benchmark_results(file_t* out_file)
     in_progress_average_t* average_times = NULL;
     const char** unique_benchmarks_names = NULL;
 
-    for (size_t benchmark = 0; benchmark < benchmarks; benchmark++)
+    for (size_t benchmark = 0; benchmark < benchmark_results->benchmarks; benchmark++)
     {
         bool unique = true;
         size_t index_non_unique;
 
         for (index_non_unique = 0; index_non_unique < unique_benchmarks; index_non_unique++)
         {
-            if (compare_null_terminated_strings(benchmark_names[benchmark], unique_benchmarks_names[index_non_unique]))
+            if (compare_null_terminated_strings(benchmark_results->benchmark_names[benchmark], unique_benchmarks_names[index_non_unique]))
             {
                 unique = false;
                 break;
@@ -286,17 +304,17 @@ int scrutiny_output_benchmark_results(file_t* out_file)
             unique_benchmarks++;
             unique_benchmarks_names = reallocarray(unique_benchmarks_names, unique_benchmarks, sizeof(char*));
             average_times = reallocarray(average_times, unique_benchmarks, sizeof(in_progress_average_t));
-            unique_benchmarks_names[unique_benchmarks - 1] = benchmark_names[benchmark];
-            average_times[unique_benchmarks - 1].running_total = benchmark_times[benchmark];
+            unique_benchmarks_names[unique_benchmarks - 1] = benchmark_results->benchmark_names[benchmark];
+            average_times[unique_benchmarks - 1].running_total = benchmark_results->benchmark_times[benchmark];
             average_times[unique_benchmarks - 1].divisor = 1;
             continue;
         }
 
-        average_times[index_non_unique].running_total += benchmark_times[benchmark];
+        average_times[index_non_unique].running_total += benchmark_results->benchmark_times[benchmark];
         average_times[index_non_unique].divisor++;
     }
 
-    fprintf(out_file, "Scrutiny ran %zu unique benchmarks for a total of %zu benchmark runs.\n\n", unique_benchmarks, benchmarks);
+    fprintf(out_file, "Scrutiny ran %zu unique benchmarks for a total of %zu benchmark runs.\n\n", unique_benchmarks, benchmark_results->benchmarks);
 
     for (size_t i = 0; i < unique_benchmarks; i++)
     {
@@ -320,25 +338,25 @@ int scrutiny_output_test_results_parsable(file_t* out_file)
     if (out_file == NULL)
         return 1;
 
-    double percent_passed = ((double)passed_tests_length / (double)(passed_tests_length + failed_tests_length)) * 100.0;
-    double percent_failed = ((double)failed_tests_length / (double)(passed_tests_length + failed_tests_length)) * 100.0;
-    double percent_cases_passed = ((double)passed_cases / (double)(passed_cases + failed_cases)) * 100.0;
-    double percent_cases_failed = ((double)failed_cases / (double)(passed_cases + failed_cases)) * 100.0;
+    long double percent_passed = ((long double)test_results->passed_tests / (long double)(test_results->passed_tests + test_results->failed_tests)) * 100.0;
+    long double percent_failed = ((long double)test_results->failed_tests / (long double)(test_results->passed_tests + test_results->failed_tests)) * 100.0;
+    long double percent_cases_passed = ((long double)test_results->passed_cases / (long double)(test_results->passed_cases + test_results->failed_cases)) * 100.0;
+    long double percent_cases_failed = ((long double)test_results->failed_cases / (long double)(test_results->passed_cases + test_results->failed_cases)) * 100.0;
 
-    fprintf(out_file, "ran %zu cases, %zu tests, %zu files\n\n", failed_cases + passed_cases, failed_tests_length + passed_tests_length, test_files_length);
+    fprintf(out_file, "ran %zu cases, %zu tests, %zu files\n\n", test_results->failed_cases + test_results->passed_cases, test_results->failed_tests + test_results->passed_tests, test_results->files);
 
     fprintf(out_file, "cases:\n");
-    fprintf(out_file, "%zu/%zu passed (%2.1lf%%)\n", passed_cases, passed_cases + failed_cases, percent_cases_passed);
-    fprintf(out_file, "%zu/%zu failed (%2.1lf%%)\n\n", failed_cases, failed_cases + passed_cases, percent_cases_failed);
+    fprintf(out_file, "%zu/%zu passed (%2.1Lf%%)\n", test_results->passed_cases, test_results->passed_cases + test_results->failed_cases, percent_cases_passed);
+    fprintf(out_file, "%zu/%zu failed (%2.1Lf%%)\n\n", test_results->failed_cases, test_results->failed_cases + test_results->passed_cases, percent_cases_failed);
 
     fprintf(out_file, "tests:\n");
-    fprintf(out_file, "%zu/%zu passed (%2.1lf%%)\n", passed_tests_length, passed_tests_length + failed_tests_length, percent_passed);
-    fprintf(out_file, "%zu/%zu failed (%2.1lf%%)\n\n", failed_tests_length, passed_tests_length + failed_tests_length, percent_failed);
+    fprintf(out_file, "%zu/%zu passed (%2.1Lf%%)\n", test_results->passed_tests, test_results->passed_tests+ test_results->failed_tests, percent_passed);
+    fprintf(out_file, "%zu/%zu failed (%2.1Lf%%)\n\n", test_results->failed_tests, test_results->passed_tests+ test_results->failed_tests, percent_failed);
 
     fprintf(out_file, "failed tests:\n");
 
-    for (size_t i = 0; i < failed_tests_length; i++)
-        fprintf(out_file, "%s\n", failed_tests[i]);
+    for (size_t i = 0; i < test_results->failed_tests; i++)
+        fprintf(out_file, "%s\n", test_results->failed_test_names[i]);
 
     fflush(out_file);
 
@@ -353,8 +371,8 @@ int scrutiny_output_benchmark_results_parsable(file_t* file)
     if (file == NULL)
         return 1;
 
-    for (size_t i = 0; i < benchmarks; i++)
-        fprintf(file, "%s:%Lf\n", benchmark_names[i], (long double)benchmark_times[i] / (long double)CLOCKS_PER_SEC);
+    for (size_t i = 0; i < benchmark_results->benchmarks; i++)
+        fprintf(file, "%s:%Lf\n", benchmark_results->benchmark_names[i], (long double)benchmark_results->benchmark_times[i] / (long double)CLOCKS_PER_SEC);
     
     if (ferror(file))
         return -1;
@@ -362,22 +380,58 @@ int scrutiny_output_benchmark_results_parsable(file_t* file)
     return 0;
 }
 
+void scrutiny_clear_results(void)
+{
+    free(test_results->passed_test_names);
+    free(test_results->failed_test_names);
+    free(test_results->file_names);
+    free(test_results);
+
+    free(benchmark_results->benchmark_names);
+    free(benchmark_results->benchmark_times);
+    free(benchmark_results->file_names);
+    free(benchmark_results);
+
+    test_results = NULL;
+    benchmark_results = NULL;
+}
+
 void scrutiny_report_assert_pass(const char* file, const char* function)
 {
+    if (test_results == NULL)
+        return;
+    
     test_file_expand_and_add(file);
     succeeded_test_expand_and_add(function);
 }
 
 void scrutiny_report_assert_fail(const char* file, const char* function, size_t line)
 {
+    if (test_results == NULL)
+    {
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+        exit(EXIT_FAILURE);
+    }
+
     test_file_expand_and_add(file);
     succeeded_test_contract_and_remove(function);
     failed_test_expand_and_add(function);
+
     printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
 }
 
 void scrutiny_report_assert_true(bool expression, const char* file, const char* function, size_t line)
 {
+    if (test_results == NULL && !expression)
+    {
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+        exit(EXIT_FAILURE);
+    }
+    else if (test_results == NULL)
+    {
+        return;
+    }
+
     test_file_expand_and_add(file);
 
     if (!expression)
@@ -393,6 +447,16 @@ void scrutiny_report_assert_true(bool expression, const char* file, const char* 
 
 void scrutiny_report_assert_false(bool expression, const char* file, const char* function, size_t line)
 {
+    if (test_results == NULL && expression)
+    {
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+        exit(EXIT_FAILURE);
+    }
+    else if (test_results == NULL)
+    {
+        return;
+    }
+
     test_file_expand_and_add(file);
 
     if (expression)
@@ -417,6 +481,14 @@ void scrutiny_report_assert_equal_ptr_data(void* expected, void* actual, size_t 
     {
         if (expected_bytes[i] != actual_bytes[i])
         {
+            if (test_results == NULL)
+            {
+                printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+                printf("\tExpected:  %u at byte %zu\n", expected_bytes[i], i);
+                printf("\tActual:    %u\n", actual_bytes[i]);
+                exit(EXIT_FAILURE);
+            }
+
             succeeded_test_contract_and_remove(function);
             failed_test_expand_and_add(function);
             printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
@@ -440,6 +512,13 @@ void scrutiny_report_assert_equal_array(void* expected, void* actual, size_t siz
     {
         if (expected_bytes[byte] != actual_bytes[byte])
         {
+            if (test_results == NULL)
+            {
+                printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+                printf("\tDifference at index: %zu\n", byte / sizeof_type);
+                exit(EXIT_FAILURE);
+            }
+
             succeeded_test_contract_and_remove(function);
             failed_test_expand_and_add(function);
             printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
@@ -474,6 +553,14 @@ void scrutiny_report_assert_equal_non_terminated_string(char* expected, char* ac
     {
         if (expected[i] != actual[i])
         {
+            if (test_results == NULL)
+            {
+                printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+                printf("\tExpected:  %c at index %zu\n", expected[i], i);
+                printf("\tActual:    %c\n", actual[i]);
+                exit(EXIT_FAILURE);
+            }
+
             succeeded_test_contract_and_remove(function);
             failed_test_expand_and_add(function);
             printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
@@ -504,7 +591,11 @@ void scrutiny_report_assert_not_equal_ptr_data(void* expected, void* actual, siz
 
     succeeded_test_contract_and_remove(function);
     failed_test_expand_and_add(function);
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
+
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
 }
 
 void scrutiny_report_assert_not_equal_array(void* expected, void* actual, size_t sizeof_type, size_t array_length, const char* file, const char* function, size_t line)
@@ -525,7 +616,11 @@ void scrutiny_report_assert_not_equal_array(void* expected, void* actual, size_t
 
     succeeded_test_contract_and_remove(function);
     failed_test_expand_and_add(function);
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
+
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
 }
 
 void scrutiny_report_assert_not_equal_string(char* expected, char* actual, const char* file, const char* function, size_t line)
@@ -558,7 +653,11 @@ void scrutiny_report_assert_not_equal_non_terminated_string(char* expected, char
 
     succeeded_test_contract_and_remove(function);
     failed_test_expand_and_add(function);
-    printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
+
+    if (test_results == NULL)
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nASSERTION FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed in " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, __func__, function, line);
+    else
+        printf(SCRUTINY_TEXT_RED SCRUTINY_TEXT_BOLD "\nTEST FAILED" SCRUTINY_TEXT_NORMAL " (%s): " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " failed " SCRUTINY_TEXT_ITALIC "%s" SCRUTINY_TEXT_NORMAL " on line %zu\n\n", file, function, __func__, line);
 }
 
 

--- a/scrutiny/scrutiny.h
+++ b/scrutiny/scrutiny.h
@@ -287,12 +287,12 @@ void scrutiny_run_benchmarks_n_times(scrutiny_benchmark_t* scrutiny_benchmarks, 
 /*
  * Gets the results of previously run tests.
  */
-scrutiny_test_results_t scrutiny_get_test_results(void);
+scrutiny_test_results_t* scrutiny_get_test_results(void);
 
 /*
  * Gets the results of previously run benchmarks.
  */
-scrutiny_benchmark_results_t scrutiny_get_benchmark_results(void);
+scrutiny_benchmark_results_t* scrutiny_get_benchmark_results(void);
 
 /*
  * Outputs test results to the given file. Tests must be run before outputting.
@@ -328,6 +328,13 @@ int scrutiny_output_test_results_parsable(file_t* out_file);
  * is set by the end of the function.
  */
 int scrutiny_output_benchmark_results_parsable(file_t* file);
+
+/*
+ * Clear scrutiny's record of test and benchmark runs, calling this will make
+ * assertions behave as state insurance in a program's runtime rather than a
+ * unit test assertion. Also clears all memory used by the results.
+ */
+void scrutiny_clear_results(void);
 
 /*
  * The following functions, while not intended to be used directly, will not


### PR DESCRIPTION
Adds support for calling assertions outside of a unit test, much like how you would the standard library's `assert()` macro but with added information like we would expect from a unit test.